### PR TITLE
Remove extra "$" character in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,9 +153,9 @@ Solve below issues:
 ## UNIX/Linux/MacOS
 
 ```bash
-    $ git clone https://github.com/linrongbin16/lin.vim ~/.vim
-    $ cd ~/.vim
-    $ ./install.sh
+    git clone https://github.com/linrongbin16/lin.vim ~/.vim
+    cd ~/.vim
+    ./install.sh
 ```
 
 The `install.sh` will automatically install below dependencies with system package manager:


### PR DESCRIPTION
when copy bash code in "Installation-UNIX/Linux/MacOS",  an error "$: command not found" occurred, remove "$" character to fix it